### PR TITLE
Add background mesh service with startup toggle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     
     // Compression
     implementation(libs.lz4.java)
+    implementation(libs.androidx.preference.ktx)
     
     // Security preferences
     implementation(libs.androidx.security.crypto)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,9 @@
     
     <!-- Notification permissions -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     
     <!-- Haptic feedback permission -->
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -50,5 +53,20 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".ForegroundMeshService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
+
+        <receiver
+            android:name=".BootCompletedReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/app/src/main/java/com/bitchat/android/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/BootCompletedReceiver.kt
@@ -3,8 +3,9 @@ package com.bitchat.android
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import androidx.preference.PreferenceManager
 import androidx.core.content.ContextCompat
+import androidx.preference.PreferenceManager
+import com.bitchat.android.ui.PREF_AUTO_START_MESH_SERVICE
 import android.os.Build
 import android.content.pm.PackageManager
 

--- a/app/src/main/java/com/bitchat/android/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/BootCompletedReceiver.kt
@@ -1,0 +1,26 @@
+package com.bitchat.android
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.preference.PreferenceManager
+import androidx.core.content.ContextCompat
+import android.os.Build
+import android.content.pm.PackageManager
+
+class BootCompletedReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            val enabled = prefs.getBoolean(PREF_AUTO_START_MESH_SERVICE, false)
+            if (enabled) {
+                val hasPermission = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                    ContextCompat.checkSelfPermission(context, android.Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+                if (hasPermission) {
+                    val serviceIntent = Intent(context, ForegroundMeshService::class.java)
+                    ContextCompat.startForegroundService(context, serviceIntent)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/ForegroundMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/ForegroundMeshService.kt
@@ -1,0 +1,77 @@
+package com.bitchat.android
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.bitchat.android.mesh.BluetoothMeshService
+
+class ForegroundMeshService : Service() {
+    private lateinit var meshService: BluetoothMeshService
+
+    companion object {
+        const val CHANNEL_ID = "MeshForegroundService"
+        const val NOTIFICATION_ID = 1
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        meshService = MeshServiceHolder.getInstance(applicationContext)
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (!meshService.isRunning()) {
+            meshService.startServices()
+        }
+        startForeground(NOTIFICATION_ID, buildNotification())
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun buildNotification(): Notification {
+        val notificationIntent = Intent(this, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            notificationIntent,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            else PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.mesh_service_notification_title))
+            .setContentText(getString(R.string.mesh_service_notification_text))
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_MIN)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .build()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.mesh_service_channel_name),
+                NotificationManager.IMPORTANCE_MIN
+            ).apply {
+                description = getString(R.string.mesh_service_channel_description)
+            }
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(channel)
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/ForegroundMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/ForegroundMeshService.kt
@@ -10,10 +10,11 @@ import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import com.bitchat.android.mesh.BluetoothMeshService
+import com.bitchat.android.ForegroundServiceDelegate
 
 class ForegroundMeshService : Service() {
     private lateinit var meshService: BluetoothMeshService
-
+    private val serviceDelegate = ForegroundServiceDelegate
     companion object {
         const val CHANNEL_ID = "MeshForegroundService"
         const val NOTIFICATION_ID = 1
@@ -22,6 +23,8 @@ class ForegroundMeshService : Service() {
     override fun onCreate() {
         super.onCreate()
         meshService = MeshServiceHolder.getInstance(applicationContext)
+        serviceDelegate.init(applicationContext)
+        serviceDelegate.attach(meshService)
         createNotificationChannel()
     }
 
@@ -29,6 +32,7 @@ class ForegroundMeshService : Service() {
         if (!meshService.isRunning()) {
             meshService.startServices()
         }
+        serviceDelegate.attach(meshService)
         startForeground(NOTIFICATION_ID, buildNotification())
         return START_STICKY
     }

--- a/app/src/main/java/com/bitchat/android/ForegroundServiceDelegate.kt
+++ b/app/src/main/java/com/bitchat/android/ForegroundServiceDelegate.kt
@@ -1,0 +1,46 @@
+package com.bitchat.android
+
+import android.content.Context
+import com.bitchat.android.mesh.BluetoothMeshDelegate
+import com.bitchat.android.model.BitchatMessage
+import com.bitchat.android.model.DeliveryAck
+import com.bitchat.android.model.ReadReceipt
+import com.bitchat.android.ui.NotificationManager
+
+/**
+ * Delegate used by the foreground service to show basic notifications
+ * when the app UI is not active.
+ */
+object ForegroundServiceDelegate : BluetoothMeshDelegate {
+    private lateinit var notificationManager: NotificationManager
+
+    fun init(context: Context) {
+        notificationManager = NotificationManager(context.applicationContext)
+        notificationManager.setAppBackgroundState(true)
+    }
+
+    fun attach(meshService: com.bitchat.android.mesh.BluetoothMeshService) {
+        meshService.delegate = this
+    }
+
+    override fun didReceiveMessage(message: BitchatMessage) {
+        if (message.isPrivate) {
+            val peerID = message.senderPeerID ?: message.sender
+            notificationManager.showPrivateMessageNotification(
+                peerID,
+                message.sender,
+                message.content
+            )
+        }
+    }
+
+    override fun didConnectToPeer(peerID: String) {}
+    override fun didDisconnectFromPeer(peerID: String) {}
+    override fun didUpdatePeerList(peers: List<String>) {}
+    override fun didReceiveChannelLeave(channel: String, fromPeer: String) {}
+    override fun didReceiveDeliveryAck(ack: DeliveryAck) {}
+    override fun didReceiveReadReceipt(receipt: ReadReceipt) {}
+    override fun decryptChannelMessage(encryptedContent: ByteArray, channel: String): String? = null
+    override fun getNickname(): String? = null
+    override fun isFavorite(peerID: String): Boolean = false
+}

--- a/app/src/main/java/com/bitchat/android/MeshServiceHolder.kt
+++ b/app/src/main/java/com/bitchat/android/MeshServiceHolder.kt
@@ -1,0 +1,15 @@
+package com.bitchat.android
+
+import android.content.Context
+import com.bitchat.android.mesh.BluetoothMeshService
+
+object MeshServiceHolder {
+    @Volatile
+    private var instance: BluetoothMeshService? = null
+
+    fun getInstance(context: Context): BluetoothMeshService {
+        return instance ?: synchronized(this) {
+            instance ?: BluetoothMeshService(context.applicationContext).also { instance = it }
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/ServiceUtils.kt
+++ b/app/src/main/java/com/bitchat/android/ServiceUtils.kt
@@ -1,0 +1,28 @@
+package com.bitchat.android
+
+import android.app.ActivityManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+
+fun startMeshForegroundService(context: Context) {
+    val intent = Intent(context, ForegroundMeshService::class.java)
+    ContextCompat.startForegroundService(context, intent)
+}
+
+fun stopMeshForegroundService(context: Context) {
+    val intent = Intent(context, ForegroundMeshService::class.java)
+    context.stopService(intent)
+}
+
+@Suppress("DEPRECATION")
+fun isServiceRunning(context: Context, serviceClass: Class<out Service>): Boolean {
+    val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager?
+    manager?.getRunningServices(Int.MAX_VALUE)?.forEach { service ->
+        if (serviceClass.name == service.service.className) {
+            return true
+        }
+    }
+    return false
+}

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -54,6 +54,8 @@ class BluetoothMeshService(private val context: Context) {
     
     // Service state management
     private var isActive = false
+
+    fun isRunning(): Boolean = isActive
     
     // Delegate for message callbacks (maintains same interface)
     var delegate: BluetoothMeshDelegate? = null

--- a/app/src/main/java/com/bitchat/android/ui/SettingsConstants.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SettingsConstants.kt
@@ -1,0 +1,3 @@
+package com.bitchat.android.ui
+
+const val PREF_AUTO_START_MESH_SERVICE = "auto_start_mesh_service"

--- a/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.sp
 import androidx.preference.PreferenceManager
 import androidx.compose.ui.platform.LocalContext
 import android.widget.Toast
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import com.bitchat.android.startMeshForegroundService
 import com.bitchat.android.stopMeshForegroundService
 import com.bitchat.android.isServiceRunning
@@ -88,9 +89,9 @@ fun SidebarOverlay(
 
                 HorizontalDivider()
                 
-                // Scrollable content
+                // Scrollable peer/channel list
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.weight(1f),
                     contentPadding = PaddingValues(vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
@@ -134,28 +135,36 @@ fun SidebarOverlay(
                         )
                     }
 
-                    item {
-                        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                        SettingsSection(
-                            isAutoStartEnabled = isAutoStartEnabled,
-                            onToggleAutoStart = { newState ->
-                                isAutoStartEnabled = newState
-                                with(sharedPreferences.edit()) {
-                                    putBoolean(PREF_AUTO_START_MESH_SERVICE, newState)
-                                    apply()
-                                }
-
-                                if (newState) {
-                                    startMeshForegroundService(context)
-                                    Toast.makeText(context, context.getString(R.string.settings_auto_start_enabled_toast), Toast.LENGTH_SHORT).show()
-                                } else {
-                                    stopMeshForegroundService(context)
-                                    Toast.makeText(context, context.getString(R.string.settings_auto_start_disabled_toast), Toast.LENGTH_SHORT).show()
-                                }
-                            }
-                        )
-                    }
                 }
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                SettingsSection(
+                    isAutoStartEnabled = isAutoStartEnabled,
+                    onToggleAutoStart = { newState ->
+                        isAutoStartEnabled = newState
+                        with(sharedPreferences.edit()) {
+                            putBoolean(PREF_AUTO_START_MESH_SERVICE, newState)
+                            apply()
+                        }
+
+                        if (newState) {
+                            startMeshForegroundService(context)
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.settings_auto_start_enabled_toast),
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        } else {
+                            stopMeshForegroundService(context)
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.settings_auto_start_disabled_toast),
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
+                )
+                Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
             }
         }
     }

--- a/app/src/main/res/drawable/ic_bitchat_notification_icon.xml
+++ b/app/src/main/res/drawable/ic_bitchat_notification_icon.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Simple chat bubble icon for notifications -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4,4h16c1.1,0 2,0.9 2,2v10c0,1.1 -0.9,2 -2,2H6l-4,4V6C2,4.9 2.9,4 4,4z" />
+    <!-- Terminal cursor -->
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M8,9h2v2h-2z" />
+    <!-- Message lines -->
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M12,9h6v1h-6z" />
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M12,11h4v1h-4z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,17 @@
     <string name="battery_optimization_continue">Continue</string>
     <string name="retry">Retry</string>
     <string name="skip">Skip</string>
+
+    <!-- Mesh Foreground Service -->
+    <string name="mesh_service_notification_title">Bitchat Active</string>
+    <string name="mesh_service_notification_text">Bluetooth mesh network is running.</string>
+    <string name="mesh_service_channel_name">Bitchat Mesh Service</string>
+    <string name="mesh_service_channel_description">Background service for Bluetooth mesh.</string>
+
+    <!-- Sidebar Settings -->
+    <string name="settings_section_title">Settings</string>
+    <string name="settings_auto_start_title">Persistent Network Mode</string>
+    <string name="settings_auto_start_summary">Keep mesh network active in background.</string>
+    <string name="settings_auto_start_enabled_toast">Persistent mode enabled.</string>
+    <string name="settings_auto_start_disabled_toast">Persistent mode disabled.</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ nordic-ble = "2.6.1"
 
 # Compression
 lz4-java = "1.8.0"
+preference = "1.2.1"
 
 # Security
 security-crypto = "1.1.0-beta01"
@@ -87,6 +88,7 @@ nordic-ble = { module = "no.nordicsemi.android:ble", version.ref = "nordic-ble" 
 
 # Compression
 lz4-java = { module = "org.lz4:lz4-java", version.ref = "lz4-java" }
+androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "preference" }
 
 # Security
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "security-crypto" }


### PR DESCRIPTION
## Summary
- create a foreground service to keep Bluetooth mesh alive
- persist mesh instance via `MeshServiceHolder`
- boot receiver starts service when enabled
- add helpers for service control
- show toggle in sidebar for persistent mode
- add notification/strings and manifest entries

## Testing
- `./gradlew assembleDebug` *(fails: SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_68897cf723f88333aec3e8124ccf0c23