### PR TITLE
Persist mesh peer ID

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     
     <!-- Notification permissions -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     
     <!-- Haptic feedback permission -->
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -50,5 +51,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".mesh.ForegroundMeshService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
+        <receiver
+            android:name=".boot.BootBroadcastReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.Lifecycle
 import com.bitchat.android.mesh.BluetoothMeshService
+import com.bitchat.android.mesh.MeshServiceHolder
 import com.bitchat.android.onboarding.BluetoothCheckScreen
 import com.bitchat.android.onboarding.BluetoothStatus
 import com.bitchat.android.onboarding.BluetoothStatusManager
@@ -66,7 +67,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         
         // Initialize core mesh service first
-        meshService = BluetoothMeshService(this)
+        meshService = MeshServiceHolder.getInstance(this)
         
         // Initialize permission management
         permissionManager = PermissionManager(this)

--- a/app/src/main/java/com/bitchat/android/boot/BootBroadcastReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/boot/BootBroadcastReceiver.kt
@@ -1,0 +1,26 @@
+package com.bitchat.android.boot
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.bitchat.android.mesh.ForegroundMeshService
+import com.bitchat.android.mesh.MeshServiceHolder
+import com.bitchat.android.util.SettingsConstants
+
+/**
+ * Receives BOOT_COMPLETED to start the mesh service when persistent
+ * connections are enabled.
+ */
+class BootBroadcastReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            val prefs = context.getSharedPreferences("bitchat_prefs", Context.MODE_PRIVATE)
+            if (prefs.getBoolean(SettingsConstants.PREF_PERSISTENT_CONNECTION, false)) {
+                // Ensure mesh service instance exists and start foreground service
+                MeshServiceHolder.getInstance(context)
+                val serviceIntent = Intent(context, ForegroundMeshService::class.java)
+                context.startForegroundService(serviceIntent)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -32,15 +32,24 @@ import kotlin.random.Random
  * - BluetoothConnectionManager: BLE connections and GATT operations
  * - PacketProcessor: Incoming packet routing
  */
-class BluetoothMeshService(private val context: Context) {
+class BluetoothMeshService(
+    private val context: Context,
+    peerId: String? = null
+) {
     
     companion object {
         private const val TAG = "BluetoothMeshService"
         private const val MAX_TTL: UByte = 7u
     }
     
+    // Helper to persist peer ID across sessions
+    private val peerIdStore = com.bitchat.android.util.PeerIdStore(context)
+
     // My peer identification - same format as iOS
-    val myPeerID: String = generateCompatiblePeerID()
+    val myPeerID: String =
+        peerId ?: peerIdStore.loadPeerId() ?: generateCompatiblePeerID().also {
+            peerIdStore.savePeerId(it)
+        }
     
     // Core components - each handling specific responsibilities
     private val encryptionService = EncryptionService(context)

--- a/app/src/main/java/com/bitchat/android/mesh/ForegroundMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/ForegroundMeshService.kt
@@ -1,0 +1,53 @@
+package com.bitchat.android.mesh
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+
+/**
+ * Lightweight foreground service wrapper that exposes the shared
+ * [BluetoothMeshService] instance. Actual foreground notification logic
+ * is intentionally omitted for brevity.
+ */
+class ForegroundMeshService : Service() {
+    private lateinit var meshService: BluetoothMeshService
+
+    companion object {
+        private const val CHANNEL_ID = "mesh_service"
+        private const val NOTIFICATION_ID = 1
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        meshService = MeshServiceHolder.getInstance(applicationContext)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Mesh Service",
+                NotificationManager.IMPORTANCE_LOW
+            )
+            val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("bitchat mesh active")
+            .setContentText("Bluetooth mesh service running")
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setOngoing(true)
+            .build()
+
+        startForeground(NOTIFICATION_ID, notification)
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+}

--- a/app/src/main/java/com/bitchat/android/mesh/MeshServiceHolder.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/MeshServiceHolder.kt
@@ -1,0 +1,24 @@
+package com.bitchat.android.mesh
+
+import android.content.Context
+import com.bitchat.android.util.PeerIdStore
+
+/**
+ * Singleton holder for [BluetoothMeshService]. Ensures a single instance
+ * is shared across the application and the foreground service.
+ */
+object MeshServiceHolder {
+    @Volatile
+    private var instance: BluetoothMeshService? = null
+
+    fun getInstance(context: Context): BluetoothMeshService {
+        return instance ?: synchronized(this) {
+            instance ?: run {
+                val store = PeerIdStore(context.applicationContext)
+                BluetoothMeshService(context.applicationContext, store.loadPeerId()).also {
+                    instance = it
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/util/PeerIdStore.kt
+++ b/app/src/main/java/com/bitchat/android/util/PeerIdStore.kt
@@ -1,0 +1,18 @@
+package com.bitchat.android.util
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Simple helper for persisting the mesh peer ID using [SharedPreferences].
+ */
+class PeerIdStore(context: Context) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("bitchat_prefs", Context.MODE_PRIVATE)
+
+    fun loadPeerId(): String? = prefs.getString(SettingsConstants.PREF_PEER_ID, null)
+
+    fun savePeerId(peerId: String) {
+        prefs.edit().putString(SettingsConstants.PREF_PEER_ID, peerId).apply()
+    }
+}

--- a/app/src/main/java/com/bitchat/android/util/SettingsConstants.kt
+++ b/app/src/main/java/com/bitchat/android/util/SettingsConstants.kt
@@ -1,0 +1,9 @@
+package com.bitchat.android.util
+
+/**
+ * Constants used for app settings stored in SharedPreferences.
+ */
+object SettingsConstants {
+    const val PREF_PEER_ID = "peer_id"
+    const val PREF_PERSISTENT_CONNECTION = "persistent_connection"
+}


### PR DESCRIPTION
## Summary
- add boot receiver to launch mesh service after reboot
- show persistent connection constant in SettingsConstants
- run mesh service as actual foreground service

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889a1b1b8c08333a302bd8ca730d38b