### PR TITLE
Persist mesh peer ID across restarts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,5 +70,14 @@
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+
+        <receiver
+            android:name=".ShutdownReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.ACTION_SHUTDOWN" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,9 +63,11 @@
         <receiver
             android:name=".BootCompletedReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="true"
+            android:directBootAware="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/main/java/com/bitchat/android/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/BootCompletedReceiver.kt
@@ -6,14 +6,16 @@ import android.content.Intent
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
 import com.bitchat.android.ui.PREF_AUTO_START_MESH_SERVICE
+import com.bitchat.android.ui.PREF_START_ON_BOOT
 import android.util.Log
 
 class BootCompletedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-            val enabled = prefs.getBoolean(PREF_AUTO_START_MESH_SERVICE, false)
-            if (enabled) {
+            val persistent = prefs.getBoolean(PREF_AUTO_START_MESH_SERVICE, false)
+            val startOnBoot = prefs.getBoolean(PREF_START_ON_BOOT, false)
+            if (persistent && startOnBoot) {
                 Log.d("BootCompletedReceiver", "Starting mesh service on boot")
                 val serviceIntent = Intent(context, ForegroundMeshService::class.java)
                 ContextCompat.startForegroundService(context, serviceIntent)

--- a/app/src/main/java/com/bitchat/android/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/BootCompletedReceiver.kt
@@ -6,8 +6,7 @@ import android.content.Intent
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
 import com.bitchat.android.ui.PREF_AUTO_START_MESH_SERVICE
-import android.os.Build
-import android.content.pm.PackageManager
+import android.util.Log
 
 class BootCompletedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -15,12 +14,9 @@ class BootCompletedReceiver : BroadcastReceiver() {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             val enabled = prefs.getBoolean(PREF_AUTO_START_MESH_SERVICE, false)
             if (enabled) {
-                val hasPermission = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
-                    ContextCompat.checkSelfPermission(context, android.Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
-                if (hasPermission) {
-                    val serviceIntent = Intent(context, ForegroundMeshService::class.java)
-                    ContextCompat.startForegroundService(context, serviceIntent)
-                }
+                Log.d("BootCompletedReceiver", "Starting mesh service on boot")
+                val serviceIntent = Intent(context, ForegroundMeshService::class.java)
+                ContextCompat.startForegroundService(context, serviceIntent)
             }
         }
     }

--- a/app/src/main/java/com/bitchat/android/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/BootCompletedReceiver.kt
@@ -11,14 +11,22 @@ import android.util.Log
 
 class BootCompletedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED ||
+            intent.action == Intent.ACTION_LOCKED_BOOT_COMPLETED
+        ) {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             val persistent = prefs.getBoolean(PREF_AUTO_START_MESH_SERVICE, false)
             val startOnBoot = prefs.getBoolean(PREF_START_ON_BOOT, false)
             if (persistent && startOnBoot) {
                 Log.d("BootCompletedReceiver", "Starting mesh service on boot")
-                val serviceIntent = Intent(context, ForegroundMeshService::class.java)
-                ContextCompat.startForegroundService(context, serviceIntent)
+                val appContext = context.applicationContext
+                val serviceIntent = Intent(appContext, ForegroundMeshService::class.java)
+                ContextCompat.startForegroundService(appContext, serviceIntent)
+            } else {
+                Log.d(
+                    "BootCompletedReceiver",
+                    "Not starting service - persistent=$persistent startOnBoot=$startOnBoot"
+                )
             }
         }
     }

--- a/app/src/main/java/com/bitchat/android/ForegroundMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/ForegroundMeshService.kt
@@ -58,15 +58,25 @@ class ForegroundMeshService : Service() {
             else PendingIntent.FLAG_UPDATE_CURRENT
         )
 
-        return NotificationCompat.Builder(this, CHANNEL_ID)
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.mesh_service_notification_title))
             .setContentText(getString(R.string.mesh_service_notification_text))
             .setSmallIcon(R.drawable.ic_notification)
             .setContentIntent(pendingIntent)
             .setOngoing(true)
+            .setAutoCancel(false)
             .setPriority(NotificationCompat.PRIORITY_MIN)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
-            .build()
+
+        if (Build.VERSION.SDK_INT >= 31) {
+            builder.setForegroundServiceBehavior(
+                NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE
+            )
+        }
+
+        return builder.build().apply {
+            flags = flags or Notification.FLAG_NO_CLEAR
+        }
     }
 
     private fun createNotificationChannel() {

--- a/app/src/main/java/com/bitchat/android/ForegroundMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/ForegroundMeshService.kt
@@ -24,7 +24,9 @@ class ForegroundMeshService : Service() {
         super.onCreate()
         meshService = MeshServiceHolder.getInstance(applicationContext)
         serviceDelegate.init(applicationContext)
-        serviceDelegate.attach(meshService)
+        if (meshService.delegate == null) {
+            serviceDelegate.attach(meshService)
+        }
         createNotificationChannel()
     }
 
@@ -32,7 +34,9 @@ class ForegroundMeshService : Service() {
         if (!meshService.isRunning()) {
             meshService.startServices()
         }
-        serviceDelegate.attach(meshService)
+        if (meshService.delegate == null || meshService.delegate === serviceDelegate) {
+            serviceDelegate.attach(meshService)
+        }
         startForeground(NOTIFICATION_ID, buildNotification())
         return START_STICKY
     }

--- a/app/src/main/java/com/bitchat/android/ForegroundMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/ForegroundMeshService.kt
@@ -28,6 +28,7 @@ class ForegroundMeshService : Service() {
             serviceDelegate.attach(meshService)
         }
         createNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/com/bitchat/android/ForegroundServiceDelegate.kt
+++ b/app/src/main/java/com/bitchat/android/ForegroundServiceDelegate.kt
@@ -6,6 +6,12 @@ import com.bitchat.android.model.BitchatMessage
 import com.bitchat.android.model.DeliveryAck
 import com.bitchat.android.model.ReadReceipt
 import com.bitchat.android.ui.NotificationManager
+import com.bitchat.android.ui.DataManager
+import com.bitchat.android.services.PrivateMessageRetentionService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 /**
  * Delegate used by the foreground service to show basic notifications
@@ -13,13 +19,26 @@ import com.bitchat.android.ui.NotificationManager
  */
 object ForegroundServiceDelegate : BluetoothMeshDelegate {
     private lateinit var notificationManager: NotificationManager
+    private lateinit var dataManager: DataManager
+    private lateinit var messageStore: PrivateMessageRetentionService
+    private var nickname: String? = null
+    private var messageStoreScope: CoroutineScope? = null
 
     fun init(context: Context) {
-        notificationManager = NotificationManager(context.applicationContext)
+        val appContext = context.applicationContext
+        notificationManager = NotificationManager(appContext)
+        dataManager = DataManager(appContext)
+        messageStore = PrivateMessageRetentionService.getInstance(appContext)
+        messageStoreScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        nickname = dataManager.loadNickname()
         notificationManager.setAppBackgroundState(true)
     }
 
     fun attach(meshService: com.bitchat.android.mesh.BluetoothMeshService) {
+        nickname = dataManager.loadNickname()
+        if (messageStoreScope == null) {
+            messageStoreScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        }
         meshService.delegate = this
     }
 
@@ -31,6 +50,10 @@ object ForegroundServiceDelegate : BluetoothMeshDelegate {
                 message.sender,
                 message.content
             )
+            // Persist the message so the UI can load it later
+            messageStoreScope?.launch {
+                messageStore.saveMessage(peerID, message)
+            }
         }
     }
 
@@ -41,6 +64,6 @@ object ForegroundServiceDelegate : BluetoothMeshDelegate {
     override fun didReceiveDeliveryAck(ack: DeliveryAck) {}
     override fun didReceiveReadReceipt(receipt: ReadReceipt) {}
     override fun decryptChannelMessage(encryptedContent: ByteArray, channel: String): String? = null
-    override fun getNickname(): String? = null
+    override fun getNickname(): String? = nickname
     override fun isFavorite(peerID: String): Boolean = false
 }

--- a/app/src/main/java/com/bitchat/android/ForegroundServiceDelegate.kt
+++ b/app/src/main/java/com/bitchat/android/ForegroundServiceDelegate.kt
@@ -48,6 +48,7 @@ object ForegroundServiceDelegate : BluetoothMeshDelegate {
         if (persistent) {
             meshService.connectionManager.setAppBackgroundState(false)
             meshService.sendBroadcastAnnounce()
+            meshService.ensureHandshakeWithPeers()
         }
 
         meshService.delegate = this

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -277,6 +277,7 @@ class MainActivity : ComponentActivity() {
             if (!permissionManager.isFirstTimeLaunch() && autoStart && serviceRunning) {
                 Log.d("MainActivity", "Mesh service already running - skipping onboarding")
                 meshService.delegate = chatViewModel
+                meshService.ensureHandshakeWithPeers()
                 handleNotificationIntent(intent)
                 mainViewModel.updateOnboardingState(OnboardingState.COMPLETE)
                 return@launch
@@ -603,6 +604,7 @@ class MainActivity : ComponentActivity() {
                 
                 // Set up mesh service delegate and start services if needed
                 meshService.delegate = chatViewModel
+                meshService.ensureHandshakeWithPeers()
                 if (!meshService.isRunning()) {
                     meshService.startServices()
                 }

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -277,6 +277,7 @@ class MainActivity : ComponentActivity() {
             if (!permissionManager.isFirstTimeLaunch() && autoStart && serviceRunning) {
                 Log.d("MainActivity", "Mesh service already running - skipping onboarding")
                 meshService.delegate = chatViewModel
+                handleNotificationIntent(intent)
                 mainViewModel.updateOnboardingState(OnboardingState.COMPLETE)
                 return@launch
             }

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -716,7 +716,12 @@ class MainActivity : ComponentActivity() {
                     Log.w("MainActivity", "Error stopping mesh services in onDestroy: ${e.message}")
                 }
             } else {
-                // App closing but service stays - reattach service delegate
+                // App closing but service stays - adjust power mode and reattach delegate
+                val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+                val persistent = prefs.getBoolean(PREF_AUTO_START_MESH_SERVICE, false)
+                if (persistent) {
+                    meshService.connectionManager.setAppBackgroundState(false)
+                }
                 ForegroundServiceDelegate.attach(meshService)
             }
         }

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -265,11 +265,22 @@ class MainActivity : ComponentActivity() {
     
     private fun checkOnboardingStatus() {
         Log.d("MainActivity", "Checking onboarding status")
-        
+
         lifecycleScope.launch {
             // Small delay to show the checking state
             delay(500)
-            
+
+            val prefs = PreferenceManager.getDefaultSharedPreferences(this@MainActivity)
+            val autoStart = prefs.getBoolean(PREF_AUTO_START_MESH_SERVICE, false)
+            val serviceRunning = isServiceRunning(this@MainActivity, ForegroundMeshService::class.java)
+
+            if (!permissionManager.isFirstTimeLaunch() && autoStart && serviceRunning) {
+                Log.d("MainActivity", "Mesh service already running - skipping onboarding")
+                meshService.delegate = chatViewModel
+                mainViewModel.updateOnboardingState(OnboardingState.COMPLETE)
+                return@launch
+            }
+
             // First check Bluetooth status (always required)
             checkBluetoothAndProceed()
         }

--- a/app/src/main/java/com/bitchat/android/ShutdownReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/ShutdownReceiver.kt
@@ -1,0 +1,21 @@
+package com.bitchat.android
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.bitchat.android.services.PrivateMessageRetentionService
+import com.bitchat.android.ui.DataManager
+import com.bitchat.android.ui.PREF_AUTO_START_MESH_SERVICE
+import com.bitchat.android.ui.PREF_START_ON_BOOT
+
+class ShutdownReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_SHUTDOWN) {
+            val appContext = context.applicationContext
+            // Preserve persistent settings while clearing everything else
+            val dataManager = DataManager(appContext)
+            dataManager.clearAllData(preservePersistentSettings = true)
+            PrivateMessageRetentionService.getInstance(appContext).clearAllMessages()
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -858,6 +858,11 @@ class BluetoothMeshService(private val context: Context) {
      * Get peer RSSI values  
      */
     fun getPeerRSSI(): Map<String, Int> = peerManager.getAllPeerRSSI()
+
+    /**
+     * Get list of currently connected peer IDs
+     */
+    fun getConnectedPeers(): List<String> = peerManager.getActivePeerIDs()
     
     /**
      * Check if we have an established Noise session with a peer  

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -14,6 +14,7 @@ import com.bitchat.android.protocol.BitchatPacket
 import com.bitchat.android.protocol.MessageType
 import com.bitchat.android.protocol.SpecialRecipients
 import com.bitchat.android.util.toHexString
+import com.bitchat.android.util.PeerIdStore
 import kotlinx.coroutines.*
 import java.util.*
 import kotlin.math.sign
@@ -39,8 +40,8 @@ class BluetoothMeshService(private val context: Context) {
         private const val MAX_TTL: UByte = 7u
     }
     
-    // My peer identification - same format as iOS
-    val myPeerID: String = generateCompatiblePeerID()
+    // My peer identification - persisted across app restarts
+    val myPeerID: String = PeerIdStore.getOrCreatePeerId(context) { generateCompatiblePeerID() }
     
     // Core components - each handling specific responsibilities
     private val encryptionService = EncryptionService(context)

--- a/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
@@ -104,8 +104,8 @@ class SecurityManager(private val encryptionService: EncryptionService, private 
         if (peerID == myPeerID) return false
 
         if (encryptionService.hasEstablishedSession(peerID)) {
-            Log.d(TAG, "Handshake already completed with $peerID")
-            return true
+            Log.d(TAG, "Handshake already completed with $peerID - resetting session")
+            encryptionService.removePeer(peerID)
         }
         
         if (packet.payload.isEmpty()) {

--- a/app/src/main/java/com/bitchat/android/services/PrivateMessageRetentionService.kt
+++ b/app/src/main/java/com/bitchat/android/services/PrivateMessageRetentionService.kt
@@ -37,6 +37,16 @@ class PrivateMessageRetentionService private constructor(private val context: Co
         }
     }
 
+    fun clearAllMessages() {
+        retentionDir.listFiles()?.forEach { file ->
+            try {
+                file.delete()
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to delete ${file.name}", e)
+            }
+        }
+    }
+
     suspend fun saveMessage(peerID: String, message: BitchatMessage) = withContext(Dispatchers.IO) {
         try {
             val file = getPeerFile(peerID)

--- a/app/src/main/java/com/bitchat/android/services/PrivateMessageRetentionService.kt
+++ b/app/src/main/java/com/bitchat/android/services/PrivateMessageRetentionService.kt
@@ -1,0 +1,98 @@
+package com.bitchat.android.services
+
+import android.content.Context
+import android.util.Log
+import com.bitchat.android.model.BitchatMessage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
+/**
+ * Simple persistence layer for private messages. Each peer gets its own file
+ * inside the app's private storage. This keeps messages available when the UI
+ * process is restarted while the foreground service continues running.
+ */
+class PrivateMessageRetentionService private constructor(private val context: Context) {
+
+    companion object {
+        private const val TAG = "PrivateMessageRetentionService"
+        @Volatile
+        private var INSTANCE: PrivateMessageRetentionService? = null
+
+        fun getInstance(context: Context): PrivateMessageRetentionService {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: PrivateMessageRetentionService(context.applicationContext).also { INSTANCE = it }
+            }
+        }
+    }
+
+    private val retentionDir = File(context.filesDir, "private_messages")
+
+    init {
+        if (!retentionDir.exists()) {
+            retentionDir.mkdirs()
+        }
+    }
+
+    suspend fun saveMessage(peerID: String, message: BitchatMessage) = withContext(Dispatchers.IO) {
+        try {
+            val file = getPeerFile(peerID)
+            val existing = loadMessagesFromFile(file).toMutableList()
+            if (existing.none { it.id == message.id }) {
+                existing.add(message)
+                existing.sortBy { it.timestamp }
+                saveMessagesToFile(file, existing)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to save message for $peerID", e)
+        }
+    }
+
+    suspend fun loadMessages(peerID: String): List<BitchatMessage> = withContext(Dispatchers.IO) {
+        try {
+            val file = getPeerFile(peerID)
+            return@withContext loadMessagesFromFile(file)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load messages for $peerID", e)
+            emptyList()
+        }
+    }
+
+    fun getPeers(): List<String> {
+        return retentionDir.listFiles()?.mapNotNull { file ->
+            val name = file.name
+            if (name.startsWith("peer_") && name.endsWith(".dat")) {
+                name.removePrefix("peer_").removeSuffix(".dat")
+            } else null
+        } ?: emptyList()
+    }
+
+    private fun getPeerFile(peerID: String): File = File(retentionDir, "peer_${peerID}.dat")
+
+    private fun loadMessagesFromFile(file: File): List<BitchatMessage> {
+        if (!file.exists()) return emptyList()
+        return try {
+            FileInputStream(file).use { fis ->
+                ObjectInputStream(fis).use { ois ->
+                    @Suppress("UNCHECKED_CAST")
+                    ois.readObject() as List<BitchatMessage>
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to load messages from ${file.name}", e)
+            emptyList()
+        }
+    }
+
+    private fun saveMessagesToFile(file: File, messages: List<BitchatMessage>) {
+        FileOutputStream(file).use { fos ->
+            ObjectOutputStream(fos).use { oos ->
+                oos.writeObject(messages)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -413,11 +413,12 @@ class ChatViewModel(
     // MARK: - Emergency Clear
     
     fun panicClearAllData() {
-        // Clear all managers
+        // Clear all managers and stored messages
         messageManager.clearAllMessages()
         channelManager.clearAllChannels()
         privateChatManager.clearAllPrivateChats()
-        dataManager.clearAllData()
+        privateMessageStore.clearAllMessages()
+        dataManager.clearAllData(preservePersistentSettings = true)
         
         // Reset nickname
         val newNickname = "anon${Random.nextInt(1000, 9999)}"

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -130,6 +130,11 @@ class ChatViewModel(
                 }
             }
         }
+
+        // Load currently connected peers from the mesh service
+        val connected = meshService.getConnectedPeers()
+        state.setConnectedPeers(connected)
+        state.setIsConnected(connected.isNotEmpty())
         
         // Initialize session state monitoring
         initializeSessionStateMonitoring()

--- a/app/src/main/java/com/bitchat/android/ui/DataManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/DataManager.kt
@@ -5,6 +5,8 @@ import android.content.SharedPreferences
 import android.util.Log
 import com.google.gson.Gson
 import kotlin.random.Random
+import com.bitchat.android.ui.PREF_AUTO_START_MESH_SERVICE
+import com.bitchat.android.ui.PREF_START_ON_BOOT
 
 /**
  * Handles data persistence operations for the chat system
@@ -195,11 +197,23 @@ class DataManager(private val context: Context) {
     
     // MARK: - Emergency Clear
     
-    fun clearAllData() {
+    fun clearAllData(preservePersistentSettings: Boolean = false) {
         _channelCreators.clear()
         _favoritePeers.clear()
         _blockedUsers.clear()
         _channelMembers.clear()
+
+        val persistent = prefs.getBoolean(PREF_AUTO_START_MESH_SERVICE, false)
+        val startOnBoot = prefs.getBoolean(PREF_START_ON_BOOT, false)
+
         prefs.edit().clear().apply()
+
+        if (preservePersistentSettings) {
+            prefs.edit().apply {
+                putBoolean(PREF_AUTO_START_MESH_SERVICE, persistent)
+                putBoolean(PREF_START_ON_BOOT, startOnBoot)
+                apply()
+            }
+        }
     }
 }

--- a/app/src/main/java/com/bitchat/android/ui/SettingsConstants.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SettingsConstants.kt
@@ -1,3 +1,4 @@
 package com.bitchat.android.ui
 
 const val PREF_AUTO_START_MESH_SERVICE = "auto_start_mesh_service"
+const val PREF_START_ON_BOOT = "start_on_boot"

--- a/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
@@ -29,6 +29,7 @@ import com.bitchat.android.stopMeshForegroundService
 import com.bitchat.android.isServiceRunning
 import com.bitchat.android.ForegroundMeshService
 import com.bitchat.android.ui.PREF_AUTO_START_MESH_SERVICE
+import com.bitchat.android.ui.PREF_START_ON_BOOT
 
 
 /**
@@ -57,6 +58,7 @@ fun SidebarOverlay(
     val context = LocalContext.current
     val sharedPreferences = remember { PreferenceManager.getDefaultSharedPreferences(context) }
     var isAutoStartEnabled by remember { mutableStateOf(sharedPreferences.getBoolean(PREF_AUTO_START_MESH_SERVICE, false)) }
+    var isStartOnBootEnabled by remember { mutableStateOf(sharedPreferences.getBoolean(PREF_START_ON_BOOT, false)) }
     
     Box(
         modifier = modifier
@@ -140,6 +142,7 @@ fun SidebarOverlay(
                 HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                 SettingsSection(
                     isAutoStartEnabled = isAutoStartEnabled,
+                    isStartOnBootEnabled = isStartOnBootEnabled,
                     onToggleAutoStart = { newState ->
                         isAutoStartEnabled = newState
                         with(sharedPreferences.edit()) {
@@ -162,6 +165,13 @@ fun SidebarOverlay(
                                 Toast.LENGTH_SHORT
                             ).show()
                         }
+                    },
+                    onToggleStartOnBoot = { newState ->
+                        isStartOnBootEnabled = newState
+                        with(sharedPreferences.edit()) {
+                            putBoolean(PREF_START_ON_BOOT, newState)
+                            apply()
+                        }
                     }
                 )
                 Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
@@ -173,7 +183,9 @@ fun SidebarOverlay(
 @Composable
 private fun SettingsSection(
     isAutoStartEnabled: Boolean,
-    onToggleAutoStart: (Boolean) -> Unit
+    isStartOnBootEnabled: Boolean,
+    onToggleAutoStart: (Boolean) -> Unit,
+    onToggleStartOnBoot: (Boolean) -> Unit
 ) {
     val colorScheme = MaterialTheme.colorScheme
 
@@ -223,6 +235,34 @@ private fun SettingsSection(
                 checked = isAutoStartEnabled,
                 onCheckedChange = null
             )
+        }
+
+        if (isAutoStartEnabled) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onToggleStartOnBoot(!isStartOnBootEnabled) }
+                    .padding(start = 8.dp, end = 8.dp, top = 0.dp, bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(Modifier.weight(1f).padding(end = 8.dp)) {
+                    Text(
+                        text = stringResource(R.string.settings_start_on_boot_title),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = colorScheme.onSurface
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_start_on_boot_summary),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colorScheme.onSurface.copy(alpha = 0.7f)
+                    )
+                }
+                Switch(
+                    checked = isStartOnBootEnabled,
+                    onCheckedChange = null
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/bitchat/android/util/PeerIdStore.kt
+++ b/app/src/main/java/com/bitchat/android/util/PeerIdStore.kt
@@ -1,0 +1,23 @@
+package com.bitchat.android.util
+
+import android.content.Context
+
+private const val PREF_NAME = "bitchat_prefs"
+private const val KEY_PEER_ID = "mesh_peer_id"
+
+/**
+ * Simple helper for storing and retrieving the mesh peer ID.
+ */
+object PeerIdStore {
+    fun getOrCreatePeerId(context: Context, generator: () -> String): String {
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        val existing = prefs.getString(KEY_PEER_ID, null)
+        return if (existing != null) {
+            existing
+        } else {
+            val newId = generator()
+            prefs.edit().putString(KEY_PEER_ID, newId).apply()
+            newId
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,8 +45,10 @@
 
     <!-- Sidebar Settings -->
     <string name="settings_section_title">Settings</string>
-    <string name="settings_auto_start_title">Persistent Network Mode</string>
+    <string name="settings_auto_start_title">Persistent Network</string>
     <string name="settings_auto_start_summary">Keep mesh network active in background.</string>
     <string name="settings_auto_start_enabled_toast">Persistent mode enabled.</string>
     <string name="settings_auto_start_disabled_toast">Persistent mode disabled.</string>
+    <string name="settings_start_on_boot_title">Start On Boot</string>
+    <string name="settings_start_on_boot_summary">Automatically start mesh network after device reboot.</string>
 </resources>


### PR DESCRIPTION
## Summary
- store mesh peer ID in shared preferences
- reuse stored peer ID when BluetoothMeshService starts

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889a6e61ebc8333990d832acf71c429